### PR TITLE
Improve Claude Code configuration

### DIFF
--- a/.claude/commands/draft.md
+++ b/.claude/commands/draft.md
@@ -1,4 +1,0 @@
-- Create a draft for a technical blog post from notes on unstaged files.
-  - Edit the target file with user confirmation
-  - If there's any content you think should be added, please suggest it.
-- If a file is specified as an argument, execute the processing even for staged files.

--- a/.claude/commands/proofreading.md
+++ b/.claude/commands/proofreading.md
@@ -1,5 +1,0 @@
-- Proofread the unstaged files in the blog directory
-  - Identify and point out inconsistencies in writing style and typos
-    - Edit these improve points
-  - Include frontmatter data in the proofreading process and verify that titles and tags are appropriate
-- If a file is specified as an argument, execute the processing even for staged files

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,77 +1,38 @@
 {
   "permissions": {
     "allow": [
+      "Bash(pnpm install*)",
       "Bash(pnpm check)",
-      "Bash(pnpm test)"
+      "Bash(pnpm test*)",
+      "Bash(pnpm build)",
+      "Bash(pnpm format)",
+      "Bash(pnpm run*)",
+      "Bash(git status)",
+      "Bash(git diff*)",
+      "Bash(git log*)",
+      "Bash(git add*)",
+      "Bash(git commit*)"
+    ],
+    "ask": [
+      "Bash(git push*)"
     ],
     "deny": [
-      "Bash(echo:*)",
-      "Bash(tee:*)",
-      "Bash(cat:*)",
-      "Bash(rm:*)",
-      "Bash(mv:*)",
-      "Bash(curl:*)",
-      "Bash(wget:*)",
-      "Bash(cp:*)",
-      "Bash(cd:*)",
-      "Bash(sed:*)",
-      "Bash(awk:*)",
-      "Bash(chmod:*)",
-      "Bash(chown:*)",
-      "Bash(sudo:*)",
-      "Bash(su:*)",
-      "Bash(ssh:*)",
-      "Bash(scp:*)",
-      "Bash(rsync:*)",
-      "Bash(telnet:*)",
-      "Bash(ftp:*)",
-      "Bash(nc:*)",
-      "Bash(netcat:*)",
-      "Bash(ifconfig:*)",
-      "Bash(ip:*)",
-      "Bash(env:*)",
-      "Bash(printenv:*)",
-      "Bash(export:*)",
-      "Bash(git config --global:*)",
-      "Bash(eval:*)",
-      "Bash(exec:*)",
-      "Bash(source:*)",
-      "Bash(sh:*)",
-      "Bash(bash:*)",
-      "Bash(zsh:*)",
-      "Bash(command:*)",
-      "Bash(xargs:*)",
-      "Bash(awk:*)",
-      "Bash(perl:*)",
-      "Bash(sed:*)",
-      "Bash(nohup:*)",
-      "Bash(screen:*)",
-      "Bash(tmux:*)",
-      "Bash(disown:*)",
-      "Bash(at:*)",
-      "Bash(cron:*)",
-      "Bash(crontab:*)",
-      "Bash(launchctl:*)",
-      "Bash(pip:*)",
-      "Bash(pip3:*)",
-      "Bash(gem:*)",
-      "Bash(bundle:*)",
-      "Bash(bundler:*)",
-      "Bash(npm install:*)",
-      "Bash(npm i:*)",
-      "Bash(yarn add:*)",
-      "Bash(yarn install:*)",
-      "Bash(pnpm add:*)",
-      "Bash(pnpm install:*)",
-      "Bash(brew install:*)",
-      "Bash(cpan:*)"
+      "Bash(sudo*)",
+      "Bash(su*)",
+      "Bash(git config --global*)"
     ],
     "disableBypassPermissionsMode": "disable"
   },
   "sandbox": {
     "enabled": true,
-    "autoAllowBashIfSandboxed": false,
-    "allowUnsandboxedCommands": false,
-    "excludedCommands": ["pnpm install"]
+    "autoAllowBashIfSandboxed": true,
+    "network": {
+      "allowedDomains": [
+        "registry.npmjs.org",
+        "zenn.dev",
+        "cdn.jsdelivr.net",
+        "github.com"
+      ]
+    }
   }
 }

--- a/.claude/skills/draft/SKILL.md
+++ b/.claude/skills/draft/SKILL.md
@@ -1,0 +1,14 @@
+---
+name: draft
+description: Create a draft for a technical blog post from notes on unstaged files in the blog directory. Use when the user asks to draft, write, or expand a blog post from notes.
+argument-hint: "[file]"
+---
+
+Create a draft for a technical blog post from notes on unstaged files.
+
+1. Find the target file:
+   - If a file is specified as an argument, use it (even if it is staged).
+   - Otherwise, look for unstaged markdown files in the `blog/` directory (`git status` / `git diff`).
+2. Expand the notes in the target file into a blog post draft, keeping the author's voice and intent.
+3. Edit the target file with user confirmation before applying changes.
+4. If there is any content you think should be added (missing context, examples, diagrams, references), suggest it to the user.

--- a/.claude/skills/proofreading/SKILL.md
+++ b/.claude/skills/proofreading/SKILL.md
@@ -1,0 +1,13 @@
+---
+name: proofreading
+description: Proofread blog posts in the blog directory, checking writing style consistency, typos, and frontmatter (title and tags). Use when the user asks to proofread, review, or polish a blog post draft.
+argument-hint: "[file]"
+---
+
+Proofread blog posts in the `blog/` directory.
+
+1. Find the target file:
+   - If a file is specified as an argument, use it (even if it is staged).
+   - Otherwise, look for unstaged markdown files in the `blog/` directory (`git status` / `git diff`).
+2. Identify and point out inconsistencies in writing style and typos, then edit the file to fix them.
+3. Include frontmatter data in the proofreading process and verify that the title and tags are appropriate for the content.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,19 +4,22 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Project Overview
 
-This is a personal website built with Astro 5 for ykokw.com. The site aggregates content from multiple sources including local blog posts, external articles, and Zenn feed.
+This is a personal website built with Astro 6 for ykokw.com. The site aggregates content from multiple sources including local blog posts, external articles, and Zenn feed.
 
 ## Development Commands
 
-- `npm run dev` - Start development server
-- `npm run dev:host` - Start development server with host access
-- `npm run build` - Type check with `astro check` and build the site
-- `npm run preview` - Preview the built site
-- `npm run format` - Format code with Prettier
-- `npm run add:post` - Create a new blog post using the script
-- `npm test` - Run tests with Vitest
-- `npm run test:watch` - Run tests in watch mode
-- `npm run test:ui` - Run tests with UI
+Use pnpm, not npm (`packageManager: pnpm@10.24.0`; CI also uses pnpm).
+
+- `pnpm dev` - Start development server
+- `pnpm dev:host` - Start development server with host access
+- `pnpm check` - Type check with `astro check`
+- `pnpm build` - Type check with `astro check` and build the site
+- `pnpm preview` - Preview the built site
+- `pnpm format` - Format code with Prettier
+- `pnpm add:post` - Create a new blog post using the script
+- `pnpm test` - Run tests with Vitest
+- `pnpm test:watch` - Run tests in watch mode
+- `pnpm test:ui` - Run tests with UI
 
 ## Architecture
 
@@ -42,7 +45,7 @@ The site uses Astro's content collections defined in `src/content.config.ts`:
 
 ### Tech Stack
 
-- **Framework**: Astro 5 with React integration
+- **Framework**: Astro 6 with React integration
 - **Styling**: Tailwind CSS 4
 - **Testing**: Vitest with coverage reporting
 - **Content**: Markdown processing with rehype plugins for external links


### PR DESCRIPTION
## 概要

Claude Code 関連設定(`.claude/settings.json` / `CLAUDE.md` / カスタムコマンド)を見直し、以下の課題を解消します。

- Bash コマンドの拒否が多すぎて Claude Code web で `pnpm install` できない
- sandbox 設定起因のエラーが多い
- 権限拒否 → 再試行ループによるトークン浪費

## 変更内容

### `.claude/settings.json`

- 約60項目あった deny リストを3項目(`sudo*` / `su*` / `git config --global*`)に縮小し、封じ込めは sandbox に委譲
- `pnpm install*` / `check` / `test*` / `build` / `format` / `run*` と読み取り・コミット系 git コマンドを allow に追加
- `git push*` は ask ルール化(ワイルドカードではフラグ位置の変動により force push だけを確実に deny できないため、push 全体を毎回確認にする)
- `sandbox.network.allowedDomains` に registry.npmjs.org / zenn.dev / cdn.jsdelivr.net / github.com を追加(ビルド時の Zenn RSS・フォント fetch が sandbox 内で通るように)
- `autoAllowBashIfSandboxed: true` に変更し、sandbox 内コマンドの許可プロンプトを削減
- 矛盾していた `excludedCommands: ["pnpm install"]`(deny と衝突)と `allowUnsandboxedCommands: false` を削除

### `CLAUDE.md`

- 開発コマンド表記を npm → pnpm に統一し、pnpm 使用を明記
- `pnpm check` を追記、Astro 5 → 6 に更新

### コマンド → スキル移行

- `.claude/commands/draft.md` / `proofreading.md` を削除し、`.claude/skills/draft/SKILL.md` / `.claude/skills/proofreading/SKILL.md` として再定義(frontmatter に `name` / `description` / `argument-hint` を明示)

## 検証

- `jq` による settings.json の構文チェック OK
- 新スキル定義がセッションのスキル一覧に認識されることを確認
- `pnpm install --frozen-lockfile` 成功、`pnpm test --run` 23件全パス
- `pnpm check` / `build` は作業環境から zenn.dev に到達できず未完走(環境のネットワーク制限。本 PR は設定ファイルのみの変更でプロダクトコードには影響なし)
- permissions / sandbox の実効確認はマージ後の新しいセッションで要確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_019crfDe85PnxKjrr39GpXUZ)_